### PR TITLE
Add unread message counts and read receipts

### DIFF
--- a/Emotion_Backend/src/controllers/chatFeatureController.js
+++ b/Emotion_Backend/src/controllers/chatFeatureController.js
@@ -63,6 +63,39 @@ export const registerUserChats = async (req, res) => {
           isOnline: { $gt: ["$currentStreak", 5] },
         },
       },
+      {
+        $lookup: {
+          from: "messages",
+          let: { userId: "$_id" },
+          pipeline: [
+            {
+              $match: {
+                $expr: {
+                  $and: [
+                    { $eq: ["$senderId", "$$userId"] },
+                    {
+                      $eq: [
+                        "$receiverId",
+                        mongoose.Types.ObjectId.createFromHexString(user_Id),
+                      ],
+                    },
+                    { $eq: ["$seen", false] },
+                  ],
+                },
+              },
+            },
+            { $count: "count" },
+          ],
+          as: "unreadMessages",
+        },
+      },
+      {
+        $addFields: {
+          unreadMessageCount: {
+            $ifNull: [{ $arrayElemAt: ["$unreadMessages.count", 0] }, 0],
+          },
+        },
+      },
     ];
 
     // Search Match
@@ -90,6 +123,7 @@ export const registerUserChats = async (req, res) => {
         computedMood: 1,
         isOnline: 1,
         latestEmotionData: 1,
+        unreadMessageCount: 1,
       },
     });
 
@@ -198,6 +232,12 @@ export const getChatHistory = async (req, res) => {
     // Explicitly cast to ObjectId
     const senderObjId = mongoose.Types.ObjectId.createFromHexString(senderId);
     const receiverObjId = mongoose.Types.ObjectId.createFromHexString(receiverId);
+
+    // Mark messages as read
+    await Message.updateMany(
+      { senderId: receiverObjId, receiverId: senderObjId, seen: false },
+      { $set: { seen: true } }
+    );
 
     const messages = await Message.find({
       $or: [

--- a/Emotion_Backend/src/socket/socket.js
+++ b/Emotion_Backend/src/socket/socket.js
@@ -36,6 +36,23 @@ export const initSocket = (io) => {
       }
     });
 
+    // mark messages as read
+    socket.on("mark_messages_read", async ({ senderId, receiverId }) => {
+      try {
+        await Message.updateMany(
+          { senderId: receiverId, receiverId: senderId, seen: false },
+          { $set: { seen: true } }
+        );
+        // Optionally notify the sender that messages were read
+        const senderSocketId = onlineUsers.get(receiverId);
+        if (senderSocketId) {
+          io.to(senderSocketId).emit("messages_read", { readerId: senderId });
+        }
+      } catch (error) {
+        console.error("Error marking messages as read:", error);
+      }
+    });
+
     // disconnect
     socket.on("disconnect", () => {
       for (let [userId, socketId] of onlineUsers.entries()) {

--- a/Emotion_Client/src/Pages/ChatDashboard/ChatDashboard.jsx
+++ b/Emotion_Client/src/Pages/ChatDashboard/ChatDashboard.jsx
@@ -12,6 +12,7 @@ import useDebounce from "../../hooks/useDebounce";
 
 import "./ChatDashboard.css";
 import { useNavigate } from "react-router-dom";
+import { socket } from "../../components/utils/socket";
 
 function ChatDashboard() {
   const { isOnline: currentUserOnline } = useUserContext();
@@ -124,6 +125,39 @@ function ChatDashboard() {
     fetchUsers(1, debouncedSearchQuery, filter);
   }, [debouncedSearchQuery, filter, fetchUsers]);
 
+  // Socket logic for unread counts
+  useEffect(() => {
+    const userId = localStorage.getItem("user_id");
+    if (!userId) return;
+
+    socket.emit("join", userId);
+
+    const handleReceiveMessage = (data) => {
+      // If we are NOT currently chatting with this user, increment their unread count
+      if (activeChatUser?._id !== data.senderId) {
+        setUsersList((prev) =>
+          prev.map((u) =>
+            u._id === data.senderId
+              ? { ...u, unreadMessageCount: (u.unreadMessageCount || 0) + 1 }
+              : u,
+          ),
+        );
+      }
+    };
+
+    const handleMessagesRead = (data) => {
+      // If someone else read our messages, we could show read receipts here if we wanted
+    };
+
+    socket.on("receive_message", handleReceiveMessage);
+    socket.on("messages_read", handleMessagesRead);
+
+    return () => {
+      socket.off("receive_message", handleReceiveMessage);
+      socket.off("messages_read", handleMessagesRead);
+    };
+  }, [activeChatUser]);
+
   /* ---------------- CHAT HANDLERS ---------------- */
   const openChatModal = useCallback((chatUser) => {
     setSelectedUser(chatUser);
@@ -138,6 +172,12 @@ function ChatDashboard() {
   const startActualChat = useCallback((user) => {
     setIsChatModalOpen(false);
     setActiveChatUser(user);
+    // Clear unread count for this user in the list
+    setUsersList((prev) =>
+      prev.map((u) =>
+        u._id === user._id ? { ...u, unreadMessageCount: 0 } : u,
+      ),
+    );
   }, []);
 
   const closeActiveChat = useCallback(() => {

--- a/Emotion_Client/src/components/LiveChatWindow/LiveChatWindow.jsx
+++ b/Emotion_Client/src/components/LiveChatWindow/LiveChatWindow.jsx
@@ -68,12 +68,20 @@ function LiveChatWindow({ chatWithUser, currentUser, onClose }) {
     }
   };
 
+  // Mark messages as read via socket
+  const markAsRead = () => {
+    if (!senderId || !receiverId) return;
+    socket.emit("mark_messages_read", { senderId, receiverId });
+  };
+
   // Socket listener for real-time messages
   useEffect(() => {
     const handleReceiveMessage = (data) => {
       // Only add message if it's from the person we are chatting with
       if (data.senderId === receiverId) {
         setMessages((prev) => [...prev, data]);
+        // Also mark as read immediately
+        markAsRead();
       }
     };
 
@@ -87,6 +95,7 @@ function LiveChatWindow({ chatWithUser, currentUser, onClose }) {
   // Fetch initial history
   useEffect(() => {
     fetchMessages();
+    markAsRead(); // Mark as read when chat opens
 
     // Re-fetch if they switch back to this tab (optional safety)
     const handleVisibilityChange = () => {
@@ -130,9 +139,9 @@ function LiveChatWindow({ chatWithUser, currentUser, onClose }) {
         text: inputText,
       });
 
-      if (isMountedRef.current) {
-        toast.success("Message sent");
-      }
+      // if (isMountedRef.current) {
+      //   toast.success("Message sent");
+      // }
     } catch (error) {
       if (isMountedRef.current) toast.error("Error sending message");
       console.error("Send error:", error.message);

--- a/Emotion_Client/src/components/UserCardsForChat/UserCardsForChat.jsx
+++ b/Emotion_Client/src/components/UserCardsForChat/UserCardsForChat.jsx
@@ -5,17 +5,16 @@ import "./UserCardsForChat.css";
 
 const UserCardsForChat = React.memo(
   React.forwardRef(({ chatUser, openChatModal, index = 0 }, ref) => {
-    // Stagger the animation delay based on index (cap at 15 so it doesn't take forever to load late items)
+    // Stagger the animation delay based on index
     const delay = Math.min(index, 15) * 0.05;
 
     return (
       <div ref={ref} className="user-card" style={{ animationDelay: `${delay}s` }}>
-        {/* {chatUser?.unreadCount > 0 && ( */}
+        {chatUser?.unreadMessageCount > 0 && (
           <span className="unread-pill">
-            {/* <FiMessageCircle /> Unread: {chatUser.unreadCount} */}
-            <FiMessageCircle /> Unread: 20
+            <FiMessageCircle /> Unread: {chatUser.unreadMessageCount}
           </span>
-        {/* )} */}
+        )}
         <div className="avatar-wrapper">
           <img
             src={chatUser.profileImage || defaultAvatar}


### PR DESCRIPTION
Backend: unread count via aggregation, mark messages seen, add mark_messages_read socket.

Frontend: socket join, handle unread count (inc/reset), emit read on open/message, show badge, remove send toast.